### PR TITLE
fix: DADSモードのパレット・シェード・モーダル間の色一貫性を修正

### DIFF
--- a/src/core/harmony.ts
+++ b/src/core/harmony.ts
@@ -227,11 +227,11 @@ export const DADS_COLORS: DADSColorDefinition[] = [
 	{ name: "Accent-Blue", chromaName: "blue", step: 600, category: "accent" },
 	{
 		name: "Accent-Light Blue",
-		chromaName: "light blue",
+		chromaName: "cyan", // DADS_CHROMAS: name="cyan", displayName="Light Blue"
 		step: 600,
 		category: "accent",
 	},
-	{ name: "Accent-Cyan", chromaName: "cyan", step: 600, category: "accent" },
+	{ name: "Accent-Cyan", chromaName: "teal", step: 600, category: "accent" }, // DADS_CHROMAS: name="teal", displayName="Cyan"
 	{ name: "Accent-Green", chromaName: "green", step: 800, category: "accent" },
 	{ name: "Accent-Lime", chromaName: "lime", step: 700, category: "accent" },
 	{


### PR DESCRIPTION
## Summary

DADSモードでパレットビュー、シェード画面、モーダルの間で色が一致しない問題を修正しました。

### 主な変更点

- **DADS固定スケールの統一**: すべてのビューで`DADS_CHROMAS`ベースの固定スケールを使用
- **PaletteConfig型拡張**: `step`プロパティを追加してDADSモード判定を正確に
- **generateFullChromaPalette修正**: harmonyColorから`step`を継承
- **表示の一貫性**: カード背景色とHEXコード表示が同じソースを使用

### 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/core/harmony.ts` | DADSカラー定義、スケール生成、step継承 |
| `src/ui/demo.ts` | パレット/シェード/モーダルのDADSモード対応 |

## Test plan

- [ ] DADSモードでパレットビューのGreenカードをクリック
- [ ] モーダル内のミニスケールがシェード画面と同じ色を表示することを確認
- [ ] Green-600とGreen-800で同じスケールの同じ位置が同じ色であることを確認
- [ ] 非DADSハーモニー（Complementary等）が正常に動作することを確認
- [ ] `npm test` で308件のテストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)